### PR TITLE
Fix unnecessary copies of reconstruction and database cache in distributed sfm stage.

### DIFF
--- a/src/base/reconstruction_manager.cc
+++ b/src/base/reconstruction_manager.cc
@@ -67,6 +67,12 @@ size_t ReconstructionManager::Add() {
   return idx;
 }
 
+size_t ReconstructionManager::Add(Reconstruction* reconsturction) {
+  const size_t idx = Size();
+  reconstructions_.emplace_back(reconsturction);
+  return idx;
+}
+
 void ReconstructionManager::Delete(const size_t idx) {
   CHECK_LT(idx, reconstructions_.size());
   reconstructions_.erase(reconstructions_.begin() + idx);

--- a/src/base/reconstruction_manager.h
+++ b/src/base/reconstruction_manager.h
@@ -58,6 +58,12 @@ class ReconstructionManager {
   // Add a new empty reconstruction and return its index.
   size_t Add();
 
+  // Add a new reconstruction and return its index. Note that the argument
+  // is used to initialize a unique_ptr, thus the caller is responsible to
+  // make the original pointer point to nullptr right after the function is
+  // called to avoid accessing memory managed by an unique_ptr.
+  size_t Add(Reconstruction* reconsturction);
+
   // Delete a specific reconstruction.
   void Delete(const size_t idx);
 

--- a/src/base/reconstruction_manager_test.cc
+++ b/src/base/reconstruction_manager_test.cc
@@ -52,6 +52,15 @@ BOOST_AUTO_TEST_CASE(TestAddGet) {
     BOOST_CHECK_EQUAL(reconstruction_manager.Get(idx).NumImages(), 0);
     BOOST_CHECK_EQUAL(reconstruction_manager.Get(idx).NumPoints3D(), 0);
   }
+  reconstruction_manager.Clear();
+  for (size_t i = 0; i < 10; ++i) {
+    const size_t idx = reconstruction_manager.Add(new Reconstruction());
+    BOOST_CHECK_EQUAL(reconstruction_manager.Size(), i + 1);
+    BOOST_CHECK_EQUAL(idx, i);
+    BOOST_CHECK_EQUAL(reconstruction_manager.Get(idx).NumCameras(), 0);
+    BOOST_CHECK_EQUAL(reconstruction_manager.Get(idx).NumImages(), 0);
+    BOOST_CHECK_EQUAL(reconstruction_manager.Get(idx).NumPoints3D(), 0);
+  }
 }
 
 BOOST_AUTO_TEST_CASE(TestDelete) {


### PR DESCRIPTION
Using smart pointer to avoid copying of reconstructions and database caches in distributed sfm stage.
The maximum virtual memory usage drops from **403GB** to **245GB** (**40 percent**) on master node when running distributed sfm on a dataset which contains 100 thousand images.
Besides, avoid copying of large chunk of memory saves roughly **1.5 days** in my case(120GB of RAM, 400GB of swap area).